### PR TITLE
group-failing-tests add config option

### DIFF
--- a/lib/cli-util.js
+++ b/lib/cli-util.js
@@ -43,6 +43,10 @@ var executeRun = module.exports.executeRun = function(cmd) {
     }
 
     config.loadAll().then(function(){
+      if(config.get('failing_test_last')) {
+        opts.failingTestsLast = true;
+      }
+    }).then(function(){
       if(!hasOrgArg) return;
 
       var usingDefault = false;


### PR DESCRIPTION
adding "failing_test_last" config option to true in dmc_config
will cause the test failures to be reported last in the test output.

This is to save me time scrolling around many lines of text to
find the failing tests.

to enable the option just add
```
"failing_test_last": true
```
to the dmc_config file.

I also messed with the output a tiny bit to show the number of failed tests in the error message. It used to just say "Failed -> test failures", now says "Failed -> N test failures